### PR TITLE
remove selectCostForCurrentPageUri

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -104,7 +104,7 @@ return /******/ (function(modules) { // webpackBootstrap
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.makeSelectViewCountForUri = exports.selectFetchingTrendingUris = exports.selectTrendingUris = exports.selectFetchingFeaturedUris = exports.selectFeaturedUris = exports.selectBlackListedOutpoints = exports.selectFetchingCostInfo = exports.selectCostForCurrentPageUri = exports.selectAllCostInfoByUri = exports.makeSelectCostInfoForUri = exports.makeSelectFetchingCostInfoForUri = exports.selectUserInviteReferralLink = exports.selectUserInviteNewErrorMessage = exports.selectUserInviteNewIsPending = exports.selectUserInviteStatusFailed = exports.selectUserInvitees = exports.selectUserInvitesRemaining = exports.selectUserInviteStatusIsPending = exports.selectAccessToken = exports.selectUserIsVerificationCandidate = exports.selectIdentityVerifyErrorMessage = exports.selectIdentityVerifyIsPending = exports.selectPhoneVerifyIsPending = exports.selectPhoneVerifyErrorMessage = exports.selectEmailVerifyErrorMessage = exports.selectEmailVerifyIsPending = exports.selectPhoneNewIsPending = exports.selectPhoneNewErrorMessage = exports.selectEmailNewErrorMessage = exports.selectEmailNewIsPending = exports.selectUserIsRewardApproved = undefined;
+exports.makeSelectViewCountForUri = exports.selectFetchingTrendingUris = exports.selectTrendingUris = exports.selectFetchingFeaturedUris = exports.selectFeaturedUris = exports.selectBlackListedOutpoints = exports.selectFetchingCostInfo = exports.selectAllCostInfoByUri = exports.makeSelectCostInfoForUri = exports.makeSelectFetchingCostInfoForUri = exports.selectUserInviteReferralLink = exports.selectUserInviteNewErrorMessage = exports.selectUserInviteNewIsPending = exports.selectUserInviteStatusFailed = exports.selectUserInvitees = exports.selectUserInvitesRemaining = exports.selectUserInviteStatusIsPending = exports.selectAccessToken = exports.selectUserIsVerificationCandidate = exports.selectIdentityVerifyErrorMessage = exports.selectIdentityVerifyIsPending = exports.selectPhoneVerifyIsPending = exports.selectPhoneVerifyErrorMessage = exports.selectEmailVerifyErrorMessage = exports.selectEmailVerifyIsPending = exports.selectPhoneNewIsPending = exports.selectPhoneNewErrorMessage = exports.selectEmailNewErrorMessage = exports.selectEmailNewIsPending = exports.selectUserIsRewardApproved = undefined;
 exports.selectPhoneToVerify = exports.selectEmailToVerify = exports.selectUserCountryCode = exports.selectUserPhone = exports.selectUserEmail = exports.selectUser = exports.selectUserIsPending = exports.selectAuthenticationIsPending = exports.selectSubscriptionClaims = exports.selectUnreadSubscriptions = exports.selectUnreadAmount = exports.selectUnreadByChannel = exports.selectSubscriptionsBeingFetched = exports.selectShowSuggestedSubs = exports.selectFirstRunCompleted = exports.selectSuggestedChannels = exports.selectIsFetchingSuggested = exports.selectSuggested = exports.selectViewMode = exports.selectIsFetchingSubscriptions = exports.selectSubscriptions = exports.selectEnabledChannelNotifications = exports.makeSelectUnreadByChannel = exports.makeSelectIsSubscribed = exports.makeSelectIsNew = exports.selectReferralReward = exports.selectRewardContentClaimIds = exports.selectRewardByType = exports.selectClaimRewardError = exports.selectClaimErrorsByType = exports.selectIsClaimRewardPending = exports.selectClaimsPendingByType = exports.selectUnclaimedRewardValue = exports.selectFetchingRewards = exports.selectUnclaimedRewards = exports.selectClaimedRewardsByTransactionId = exports.selectClaimedRewards = exports.selectClaimedRewardsById = exports.selectUnclaimedRewardsByType = exports.makeSelectRewardByType = exports.makeSelectRewardAmountByType = exports.makeSelectIsRewardClaimPending = exports.makeSelectClaimRewardError = exports.selectIsAuthenticating = exports.selectAuthToken = exports.statsReducer = exports.homepageReducer = exports.blacklistReducer = exports.costInfoReducer = exports.userReducer = exports.subscriptionsReducer = exports.rewardsReducer = exports.authReducer = exports.doFetchViewCount = exports.doFetchTrendingUris = exports.doFetchFeaturedUris = exports.doBlackListedOutpointsSubscribe = exports.doFetchCostInfoForUri = exports.doUserInviteNew = exports.doUserIdentityVerify = exports.doUserResendVerificationEmail = exports.doFetchAccessToken = exports.doUserPhoneVerify = exports.doUserPhoneVerifyFailure = exports.doUserPhoneReset = exports.doUserPhoneNew = exports.doUserEmailVerify = exports.doUserEmailVerifyFailure = exports.doUserEmailToVerify = exports.doUserCheckEmailVerified = exports.doUserEmailNew = exports.doUserFetch = exports.doAuthenticate = exports.doInstallNew = exports.doFetchInviteStatus = exports.setSubscriptionLatest = exports.doUpdateUnreadSubscriptions = exports.doShowSuggestedSubs = exports.doSetViewMode = exports.doRemoveUnreadSubscriptions = exports.doRemoveUnreadSubscription = exports.doFetchRecommendedSubscriptions = exports.doFetchMySubscriptions = exports.doCompleteFirstRun = exports.doCheckSubscriptionsInit = exports.doCheckSubscriptions = exports.doCheckSubscription = exports.doChannelSubscriptionDisableNotifications = exports.doChannelSubscriptionEnableNotifications = exports.doChannelUnsubscribe = exports.doChannelSubscribe = exports.doFetchRewardedContent = exports.doClaimRewardClearError = exports.doClaimEligiblePurchaseRewards = exports.doClaimRewardType = exports.doRewardList = exports.doGenerateAuthToken = exports.rewards = exports.Lbryio = exports.LBRYINC_ACTIONS = undefined;
 
 var _auth = __webpack_require__(1);
@@ -878,12 +878,6 @@ Object.defineProperty(exports, 'selectAllCostInfoByUri', {
   enumerable: true,
   get: function get() {
     return _cost_info3.selectAllCostInfoByUri;
-  }
-});
-Object.defineProperty(exports, 'selectCostForCurrentPageUri', {
-  enumerable: true,
-  get: function get() {
-    return _cost_info3.selectCostForCurrentPageUri;
   }
 });
 Object.defineProperty(exports, 'selectFetchingCostInfo', {
@@ -10306,11 +10300,9 @@ var selectIsAuthenticating = exports.selectIsAuthenticating = (0, _reselect.crea
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.makeSelectFetchingCostInfoForUri = exports.selectFetchingCostInfo = exports.selectCostForCurrentPageUri = exports.makeSelectCostInfoForUri = exports.selectAllCostInfoByUri = exports.selectState = undefined;
+exports.makeSelectFetchingCostInfoForUri = exports.selectFetchingCostInfo = exports.makeSelectCostInfoForUri = exports.selectAllCostInfoByUri = exports.selectState = undefined;
 
 var _reselect = __webpack_require__(10);
-
-var _lbryRedux = __webpack_require__(4);
 
 var selectState = exports.selectState = function selectState(state) {
   return state.costInfo || {};
@@ -10325,10 +10317,6 @@ var makeSelectCostInfoForUri = exports.makeSelectCostInfoForUri = function makeS
     return costInfos && costInfos[uri];
   });
 };
-
-var selectCostForCurrentPageUri = exports.selectCostForCurrentPageUri = (0, _reselect.createSelector)(selectAllCostInfoByUri, _lbryRedux.selectCurrentParams, function (costInfo, params) {
-  return params.uri && costInfo[params.uri] ? costInfo[params.uri].cost : undefined;
-});
 
 var selectFetchingCostInfo = exports.selectFetchingCostInfo = (0, _reselect.createSelector)(selectState, function (state) {
   return state.fetching || {};

--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,6 @@ export {
   makeSelectFetchingCostInfoForUri,
   makeSelectCostInfoForUri,
   selectAllCostInfoByUri,
-  selectCostForCurrentPageUri,
   selectFetchingCostInfo,
 } from 'redux/selectors/cost_info';
 export { selectBlackListedOutpoints } from 'redux/selectors/blacklist';

--- a/src/redux/selectors/cost_info.js
+++ b/src/redux/selectors/cost_info.js
@@ -1,5 +1,4 @@
 import { createSelector } from 'reselect';
-import { selectCurrentParams } from 'lbry-redux';
 
 export const selectState = state => state.costInfo || {};
 
@@ -7,12 +6,6 @@ export const selectAllCostInfoByUri = createSelector(selectState, state => state
 
 export const makeSelectCostInfoForUri = uri =>
   createSelector(selectAllCostInfoByUri, costInfos => costInfos && costInfos[uri]);
-
-export const selectCostForCurrentPageUri = createSelector(
-  selectAllCostInfoByUri,
-  selectCurrentParams,
-  (costInfo, params) => (params.uri && costInfo[params.uri] ? costInfo[params.uri].cost : undefined)
-);
 
 export const selectFetchingCostInfo = createSelector(selectState, state => state.fetching || {});
 


### PR DESCRIPTION
Nothing is using this and `selectCurrentParams` will be removed from `lbry-redux` in https://github.com/lbryio/lbry-redux/pull/124