### PR TITLE
fix: claim search

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -1546,16 +1546,14 @@ const doCheckSubscription = (subscriptionUri, shouldNotify) => (dispatch, getSta
 
   if (!savedSubscription) {
     throw Error(`Trying to find new content for ${subscriptionUri} but it doesn't exist in your subscriptions`);
-  }
+  } // We may be duplicating calls here. Can this logic be baked into doFetchClaimsByChannel?
 
-  const {
-    claimId
-  } = lbryRedux.parseURI(subscriptionUri); // We may be duplicating calls here. Can this logic be baked into doFetchClaimsByChannel?
 
   lbryRedux.Lbry.claim_search({
-    channel_id: claimId,
+    channel_name: subscriptionUri,
     page: 1,
-    page_size: PAGE_SIZE
+    page_size: PAGE_SIZE,
+    winning: true
   }).then(result => {
     const {
       items: claimsInChannel
@@ -2024,7 +2022,7 @@ function doSetDefaultAccount() {
       } = accountList;
       let defaultId;
 
-      for (let i = 0; i < accounts.length; i++) {
+      for (let i = 0; i < accounts.length; ++i) {
         if (accounts[i].satoshis > 0) {
           defaultId = accounts[i].id;
           break;

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -2531,16 +2531,14 @@ var doCheckSubscription = function doCheckSubscription(subscriptionUri, shouldNo
 
     if (!savedSubscription) {
       throw Error("Trying to find new content for ".concat(subscriptionUri, " but it doesn't exist in your subscriptions"));
-    }
-
-    var _parseURI = Object(lbry_redux__WEBPACK_IMPORTED_MODULE_3__["parseURI"])(subscriptionUri),
-        claimId = _parseURI.claimId; // We may be duplicating calls here. Can this logic be baked into doFetchClaimsByChannel?
+    } // We may be duplicating calls here. Can this logic be baked into doFetchClaimsByChannel?
 
 
     lbry_redux__WEBPACK_IMPORTED_MODULE_3__["Lbry"].claim_search({
-      channel_id: claimId,
+      channel_name: subscriptionUri,
       page: 1,
-      page_size: constants_claim__WEBPACK_IMPORTED_MODULE_0__["PAGE_SIZE"]
+      page_size: constants_claim__WEBPACK_IMPORTED_MODULE_0__["PAGE_SIZE"],
+      winning: true
     }).then(function (result) {
       var claimsInChannel = result.items; // may happen if subscribed to an abandoned channel or an empty channel
 
@@ -2623,8 +2621,8 @@ var doChannelSubscribe = function doChannelSubscribe(subscription) {
     }); // if the user isn't sharing data, keep the subscriptions entirely in the app
 
     if (isSharingData) {
-      var _parseURI2 = Object(lbry_redux__WEBPACK_IMPORTED_MODULE_3__["parseURI"])(subscription.uri),
-          claimId = _parseURI2.claimId; // They are sharing data, we can store their subscriptions in our internal database
+      var _parseURI = Object(lbry_redux__WEBPACK_IMPORTED_MODULE_3__["parseURI"])(subscription.uri),
+          claimId = _parseURI.claimId; // They are sharing data, we can store their subscriptions in our internal database
 
 
       lbryio__WEBPACK_IMPORTED_MODULE_6__["default"].call('subscription', 'new', {
@@ -2651,8 +2649,8 @@ var doChannelUnsubscribe = function doChannelUnsubscribe(subscription) {
     });
 
     if (isSharingData) {
-      var _parseURI3 = Object(lbry_redux__WEBPACK_IMPORTED_MODULE_3__["parseURI"])(subscription.uri),
-          claimId = _parseURI3.claimId;
+      var _parseURI2 = Object(lbry_redux__WEBPACK_IMPORTED_MODULE_3__["parseURI"])(subscription.uri),
+          claimId = _parseURI2.claimId;
 
       lbryio__WEBPACK_IMPORTED_MODULE_6__["default"].call('subscription', 'delete', {
         claim_id: claimId
@@ -2705,8 +2703,8 @@ var doFetchMySubscriptions = function doFetchMySubscriptions() {
           dbSubMap[sub.claim_id] = 1;
         });
         reduxSubscriptions.forEach(function (sub) {
-          var _parseURI4 = Object(lbry_redux__WEBPACK_IMPORTED_MODULE_3__["parseURI"])(sub.uri),
-              claimId = _parseURI4.claimId;
+          var _parseURI3 = Object(lbry_redux__WEBPACK_IMPORTED_MODULE_3__["parseURI"])(sub.uri),
+              claimId = _parseURI3.claimId;
 
           reduxSubMap[claimId] = 1;
 
@@ -3452,7 +3450,7 @@ function doSetDefaultAccount() {
       var accounts = accountList.lbc_mainnet;
       var defaultId;
 
-      for (var i = 0; i < accounts.length; i++) {
+      for (var i = 0; i < accounts.length; ++i) {
         if (accounts[i].satoshis > 0) {
           defaultId = accounts[i].id;
           break;

--- a/src/redux/actions/subscriptions.js
+++ b/src/redux/actions/subscriptions.js
@@ -156,10 +156,13 @@ export const doCheckSubscription = (subscriptionUri: string, shouldNotify?: bool
     );
   }
 
-  const { claimId } = parseURI(subscriptionUri);
-
   // We may be duplicating calls here. Can this logic be baked into doFetchClaimsByChannel?
-  Lbry.claim_search({ channel_id: claimId, page: 1, page_size: PAGE_SIZE }).then(result => {
+  Lbry.claim_search({
+    channel_name: subscriptionUri,
+    page: 1,
+    page_size: PAGE_SIZE,
+    winning: true,
+  }).then(result => {
     const { items: claimsInChannel } = result;
 
     // may happen if subscribed to an abandoned channel or an empty channel


### PR DESCRIPTION
to use channel uri instead of claim id (support for vanity resolution)

I did not test this locally - would need to bring it into an Android build. The --winning parameter is required so that only the winning channel's claims are returned. 