### PR TITLE
don't clear user during fetch

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -2400,8 +2400,7 @@ reducers$2[lbryRedux.ACTIONS.AUTHENTICATION_FAILURE] = state => Object.assign({}
 });
 
 reducers$2[lbryRedux.ACTIONS.USER_FETCH_STARTED] = state => Object.assign({}, state, {
-  userIsPending: true,
-  user: defaultState$3.user
+  userIsPending: true
 });
 
 reducers$2[lbryRedux.ACTIONS.USER_FETCH_SUCCESS] = (state, action) => Object.assign({}, state, {

--- a/src/redux/reducers/user.js
+++ b/src/redux/reducers/user.js
@@ -40,7 +40,6 @@ reducers[ACTIONS.AUTHENTICATION_FAILURE] = state =>
 reducers[ACTIONS.USER_FETCH_STARTED] = state =>
   Object.assign({}, state, {
     userIsPending: true,
-    user: defaultState.user,
   });
 
 reducers[ACTIONS.USER_FETCH_SUCCESS] = (state, action) =>


### PR DESCRIPTION
The current behavior prevents checking if user values changed ex:

`previousUserId === undefined && userId`

because when we call fetchUser, the user is cleared out.