### PR TITLE
unlock wallet if needed before syncing

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -2501,6 +2501,8 @@ function doGetSync(passedPassword, callback) {
         }) => {
           dispatch(doSetSync('', walletHash, syncApplyData, password));
           handleCallback();
+        }).catch(error => {
+          handleCallback(error);
         });
       }
     });

--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -2427,73 +2427,82 @@ function doGetSync(passedPassword, callback) {
       type: GET_SYNC_STARTED
     });
     const data = {};
-    lbryRedux.Lbry.sync_hash().then(hash => {
-      Lbryio.call('sync', 'get', {
-        hash
-      }, 'post').then(response => {
-        const syncHash = response.hash;
-        data.syncHash = syncHash;
-        data.syncData = response.data;
-        data.hasSyncedWallet = true;
+    lbryRedux.Lbry.wallet_status().then(status => {
+      if (status.is_locked) {
+        return lbryRedux.Lbry.wallet_unlock({
+          password
+        });
+      }
+    }).then(() => lbryRedux.Lbry.sync_hash()).then(hash => Lbryio.call('sync', 'get', {
+      hash
+    }, 'post')).then(response => {
+      const syncHash = response.hash;
+      data.syncHash = syncHash;
+      data.syncData = response.data;
+      data.hasSyncedWallet = true;
 
-        if (response.changed) {
-          return lbryRedux.Lbry.sync_apply({
-            password,
-            data: response.data
-          }).then(({
-            hash: walletHash,
-            data: walletData
-          }) => {
-            dispatch({
-              type: GET_SYNC_COMPLETED,
-              data
-            });
+      if (response.changed) {
+        return lbryRedux.Lbry.sync_apply({
+          password,
+          data: response.data
+        });
+      }
+    }).then(response => {
+      if (!response) {
+        dispatch({
+          type: GET_SYNC_COMPLETED,
+          data
+        });
+        handleCallback();
+        return;
+      }
 
-            if (walletHash !== syncHash) {
-              // different local hash, need to synchronise
-              dispatch(doSetSync(syncHash, walletHash, walletData));
-              handleCallback();
-            }
-          });
-        } else {
-          dispatch({
-            type: GET_SYNC_COMPLETED,
-            data
-          });
-          handleCallback();
-        }
-      }).catch(() => {
-        if (data.hasSyncedWallet) {
-          const error = 'Error getting synced wallet';
-          dispatch({
-            type: GET_SYNC_FAILED,
-            data: {
-              error
-            }
-          });
-          handleCallback(error);
-        } else {
-          // user doesn't have a synced wallet
-          dispatch({
-            type: GET_SYNC_COMPLETED,
-            data: {
-              hasSyncedWallet: false,
-              syncHash: null
-            }
-          }); // call sync_apply to get data to sync
-          // first time sync. use any string for old hash
+      const {
+        hash: walletHash,
+        data: walletData
+      } = response;
 
-          lbryRedux.Lbry.sync_apply({
-            password
-          }).then(({
-            hash: walletHash,
-            data: syncApplyData
-          }) => {
-            dispatch(doSetSync('', walletHash, syncApplyData, password));
-            handleCallback();
-          });
-        }
+      if (walletHash !== data.syncHash) {
+        // different local hash, need to synchronise
+        dispatch(doSetSync(data.syncHash, walletHash, walletData));
+      }
+
+      dispatch({
+        type: GET_SYNC_COMPLETED,
+        data
       });
+      handleCallback();
+    }).catch(() => {
+      if (data.hasSyncedWallet) {
+        const error = 'Error getting synced wallet';
+        dispatch({
+          type: GET_SYNC_FAILED,
+          data: {
+            error
+          }
+        });
+        handleCallback(error);
+      } else {
+        // user doesn't have a synced wallet
+        dispatch({
+          type: GET_SYNC_COMPLETED,
+          data: {
+            hasSyncedWallet: false,
+            syncHash: null
+          }
+        }); // call sync_apply to get data to sync
+        // first time sync. use any string for old hash
+
+        lbryRedux.Lbry.sync_apply({
+          password
+        }).then(({
+          hash: walletHash,
+          data: syncApplyData
+        }) => {
+          dispatch(doSetSync('', walletHash, syncApplyData, password));
+          handleCallback();
+        });
+      }
     });
   };
 }

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -4067,6 +4067,8 @@ function doGetSync(passedPassword, callback) {
               syncApplyData = _ref.data;
           dispatch(doSetSync('', walletHash, syncApplyData, password));
           handleCallback();
+        })["catch"](function (error) {
+          handleCallback(error);
         });
       }
     });

--- a/src/redux/actions/sync.js
+++ b/src/redux/actions/sync.js
@@ -151,10 +151,14 @@ export function doGetSync(passedPassword, callback) {
 
           // call sync_apply to get data to sync
           // first time sync. use any string for old hash
-          Lbry.sync_apply({ password }).then(({ hash: walletHash, data: syncApplyData }) => {
-            dispatch(doSetSync('', walletHash, syncApplyData, password));
-            handleCallback();
-          });
+          Lbry.sync_apply({ password })
+            .then(({ hash: walletHash, data: syncApplyData }) => {
+              dispatch(doSetSync('', walletHash, syncApplyData, password));
+              handleCallback();
+            })
+            .catch(error => {
+              handleCallback(error);
+            });
         }
       });
   };


### PR DESCRIPTION
Also attempted to make some of the promises easier to follow. I think ideally we would just try to call `sync_apply`, then if the wallet is locked, call `wallet_unlock`. However, this is not possible until https://github.com/lbryio/lbry-sdk/issues/1118 is implemented