### PR TITLE
pass error back to sync callback

### DIFF
--- a/dist/bundle.es.js
+++ b/dist/bundle.es.js
@@ -2502,13 +2502,13 @@ function doSetSync(oldHash, newHash, data) {
 function doGetSync(passedPassword, callback) {
   const password = passedPassword === null || passedPassword === undefined ? '' : passedPassword;
 
-  function handleCallback() {
+  function handleCallback(error) {
     if (callback) {
       if (typeof callback !== 'function') {
         throw new Error('Second argument passed to "doGetSync" must be a function');
       }
 
-      callback();
+      callback(error);
     }
   }
 

--- a/src/redux/actions/sync.js
+++ b/src/redux/actions/sync.js
@@ -80,13 +80,13 @@ export function doSetSync(oldHash, newHash, data) {
 export function doGetSync(passedPassword, callback) {
   const password = passedPassword === null || passedPassword === undefined ? '' : passedPassword;
 
-  function handleCallback() {
+  function handleCallback(error) {
     if (callback) {
       if (typeof callback !== 'function') {
         throw new Error('Second argument passed to "doGetSync" must be a function');
       }
 
-      callback();
+      callback(error);
     }
   }
 


### PR DESCRIPTION
Guess this slipped through. We were passing errors to `handleCallback` but not the rest of the way through.